### PR TITLE
Updated deploy-pages action

### DIFF
--- a/.github/workflows/deploy_page.yaml
+++ b/.github/workflows/deploy_page.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: ./docpage/build


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a newer version of the `upload-pages-artifact` action.

Workflow maintenance:

* Updated the `actions/upload-pages-artifact` action from version `v2` to `v3` in `.github/workflows/deploy_page.yaml` to ensure compatibility with the latest features and improvements.